### PR TITLE
Support trinodb and other Presto compatible docker images

### DIFF
--- a/lib/tiny-presto/cluster.rb
+++ b/lib/tiny-presto/cluster.rb
@@ -6,9 +6,9 @@ module TinyPresto
   # Represents a Presto cluster
   #
   class Cluster
-    def initialize(tag = 'latest')
+    def initialize(image = 'trinodb/trino', tag = 'latest')
       @tag = tag
-      @image_name = "prestosql/presto:#{@tag}"
+      @image_name = "#{image}:#{@tag}"
     end
 
     # Launch Presto cluster running on Docker container


### PR DESCRIPTION
Due to the transition from prestosql to trinodb, seems that prestosql/presto docker image got unavailable on DockerHub.
https://hub.docker.com/r/prestosql/presto

It would be nice if tiny-presto supports [trinodb](https://hub.docker.com/r/trinodb/trino) images. Also, we may be able to use [starburstdata](https://hub.docker.com/r/starburstdata/presto) images if we need to use prestosql compatible docker image.