### PR TITLE
Bump dependency library versions to support ruby 3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        ruby-version: ["2.6", "2.7", "3.0", "3.1"]
+        ruby-version: ["2.7", "3.0", "3.1"]
 
     steps:
     - uses: actions/checkout@v3

--- a/tiny-presto.gemspec
+++ b/tiny-presto.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.7.0'
 
-  gem.add_dependency 'docker-api', ['>= 1.34.0', '< 3.0']
+  gem.add_dependency 'docker-api', ['>= 2.0.0', '< 3.0']
   gem.add_dependency 'trino-client'
 
   gem.add_development_dependency 'rake', ['~> 13.0.0']

--- a/tiny-presto.gemspec
+++ b/tiny-presto.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.has_rdoc = false
 
-  gem.required_ruby_version = '>= 2.4.0'
+  gem.required_ruby_version = '>= 2.7.0'
 
-  gem.add_dependency 'docker-api', ['~> 1.34.0']
+  gem.add_dependency 'docker-api', ['>= 1.34.0', '< 3.0']
   gem.add_dependency 'trino-client'
 
   gem.add_development_dependency 'rake', ['~> 13.0.0']


### PR DESCRIPTION
## Overview

- Relax `docker-api` gem version restriction. Ruby scripts using `docker-api` v1 don't work with ruby 3.
- Upgrade the minimal ruby version to 2.7. Ruby 2.6 is EOL now.
  - Drop ruby 2.6 from testing target versions in Github Actions. 
